### PR TITLE
Run vimboy if the string 'vimboy' is included in the filetype

### DIFF
--- a/ftplugin/vimboy.vim
+++ b/ftplugin/vimboy.vim
@@ -45,7 +45,7 @@ endf
 
 " Syntax highlight each filename of the current directory
 fu s:UpdateLinksInThisTab()
-    if &filetype != "vimboy"
+    if &filetype !~ "vimboy"
         return
     endif
 


### PR DESCRIPTION
Hi.

I just came across vimboy, and I think it's awesome! It'd be even better though if it had support for Vim's function to attach two or more filetypes to a single file.

I went ahead and changed vimboy so it would allow that (by switching a single `=` to `~`), but to be honest, there is probably a much cleaner way of doing this -- I'm not entirely sure how though, so I went ahead and did it the simple way -- feel free to reject the PR if it is not to your liking :-)

Cheers,
DataWraith