### PR TITLE
fix: make sure that vimboy_dir is loaded when defining the syntax

### DIFF
--- a/syntax/vimboy.vim
+++ b/syntax/vimboy.vim
@@ -4,7 +4,7 @@ highlight link vimboyDeadlink Error
 syntax clear vimboyLink
 syntax clear vimboyDeadlink
 
-if exists("g:loaded_vimboy")
+if exists("b:vimboy_dir")
     if g:vimboy_hl_deadlinks && ! g:vimboy_autolink
         syntax match vimboyDeadlink /\[[^\]]*\]/
     endif


### PR DESCRIPTION
The order of execution of the syntax and ftplugin scripts seems to vary.
This change makes sure, that the buffer variable is set.

Before, we checked `g:vimboy_loaded`.
The new check for `b:vimboy_dir` does also what we want,
because the latter will be set while loading the plugin as well.

fixes #5