### PR TITLE
ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
doc/tags is a file generated by :helptags (i think) automatically,
we don't need to keep track of it in git.