### PR TITLE
fix: open links case insensitive independent of configuration

### DIFF
--- a/ftplugin/vimboy.vim
+++ b/ftplugin/vimboy.vim
@@ -11,7 +11,7 @@
 " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 " GNU General Public License for more details.
 
-" Only process this script once.
+" Only process this script once, but initialize the buffer every time.
 if exists("g:loaded_vimboy")
     call s:InitBuffer()
     finish
@@ -32,7 +32,7 @@ endif
 " We run this once per buffer.
 fu s:InitBuffer()
     " Set base dir to dir the current file is in.
-    let b:vimboy_dir = expand("%:p:h")."/"
+    let b:vimboy_dir = expand("%:p:h")
 
     " When writing a file, refresh syntax in all buffers,
     " because the links might have changed.
@@ -69,7 +69,7 @@ fu s:OpenPage(name)
         let l:files = split(glob("*"),'[\r\n]\+')
         execute "cd -"
         for l:file in l:files
-            if l:file =~ '\V\^'.escape(a:name, '/\').'\$'
+            if l:file =~? '\V\^'.escape(a:name, '/\').'\$'
                 execute l:editcmd." ".b:vimboy_dir."/".fnameescape(l:file)
                 return
             endif


### PR DESCRIPTION
The main change is switching from `=~` to `=~?`, which matches the
filename case insensitive _independent_ of the users' configuration.
As this loop only is executed when we don't find the exact match, this
is always what should happen.

While at it, remove an unnecesary path divider and improve code
documentation a little bit.